### PR TITLE
ODP-566 | HADOOP-18497 CVE-2022-42889 upgrade common-text from 1.4 to 1.10.0

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -116,7 +116,7 @@
     <commons-logging-api.version>1.1</commons-logging-api.version>
     <commons-math3.version>3.1.1</commons-math3.version>
     <commons-net.version>3.6</commons-net.version>
-    <commons-text.version>1.4</commons-text.version>
+    <commons-text.version>1.10.0</commons-text.version>
 
     <!-- Apache Ratis version -->
     <ratis.version>0.3.0-eca3531-SNAPSHOT</ratis.version>


### PR DESCRIPTION
Upgraded version to 1.10.0 and done some testing in hive beeline.