### PR TITLE
ODP-2284 - upgrade aws-java-sdk.version  to 1.12.100

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -180,7 +180,7 @@
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
-    <aws-java-sdk.version>1.11.901</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.100</aws-java-sdk.version>
     <hsqldb.version>2.3.4</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>
     <!-- the version of Hadoop declared in the version resources; can be overridden


### PR DESCRIPTION
ODP-2284 - upgrade aws-java-sdk.version  to 1.12.100 to fix CVE-2017-17485