### PR TITLE
ODP-1434 Fixing case sensitivity issue with jackson upgrade on registering yarn-service

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/api/records/PlacementScope.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/main/java/org/apache/hadoop/yarn/service/api/records/PlacementScope.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.api.resource.PlacementConstraints;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 import io.swagger.annotations.ApiModel;
 
@@ -43,6 +44,13 @@ public enum PlacementScope {
 
   public String getValue() {
     return value;
+  }
+
+  @JsonCreator
+  public static PlacementScope fromString(String key) {
+    return key == null
+            ? null
+            : PlacementScope.valueOf(key.toUpperCase());
   }
 
   @Override


### PR DESCRIPTION
Removing Jackson 1.x introduced dependency on Jackson 2.1 to support Json mapping, causing a case insensitive issue while registering yarn-service 

`2024-11-21 11:45:40,438 ERROR utils.JsonSerDeser (JsonSerDeser.java:fromStream(139)) - Exception while parsing json input stream
com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `org.apache.hadoop.yarn.service.api.records.PlacementScope` from String "NODE": not one of the values accepted for Enum class: [node, rack]
 at [Source: (org.apache.hadoop.hdfs.client.HdfsDataInputStream); line: 82, column: 22] (through reference chain: org.apache.hadoop.yarn.service.api.records.Service["components"]->java.util.ArrayList[0]->org.apache.hadoop.yarn.service.api.records.Component["placement_policy"]->org.apache.hadoop.yarn.service.api.records.PlacementPolicy["constraints"]->java.util.ArrayList[0]->org.apache.hadoop.yarn.service.api.records.PlacementConstraint["scope"])
	at com.fasterxml.jackson.databind.exc.InvalidFormatException.from(InvalidFormatException.java:67)
	at com.fasterxml.jackson.databind.DeserializationContext.weirdStringException(DeserializationContext.java:1851)
	at com.fasterxml.jackson.databind.DeserializationContext.handleWeirdStringValue(DeserializationContext.java:1`