### PR TITLE
Client module duplicate classes

### DIFF
--- a/hadoop-client-modules/hadoop-client-check-invariants/pom.xml
+++ b/hadoop-client-modules/hadoop-client-check-invariants/pom.xml
@@ -104,6 +104,18 @@
                         <ignoreClass>*</ignoreClass>
                       </ignoreClasses>
                     </dependency>
+                    <!--
+                      Multi-release jars include a Java 9 module descriptor at META-INF/versions/9/module-info.class.
+                      This entry can legitimately appear in multiple Hadoop client artifacts and should not fail the
+                      duplicate class check.
+                    -->
+                    <dependency>
+                      <groupId>org.apache.hadoop</groupId>
+                      <artifactId>hadoop-client-runtime</artifactId>
+                      <ignoreClasses>
+                        <ignoreClass>META-INF/versions/9/module-info.class</ignoreClass>
+                      </ignoreClasses>
+                    </dependency>
                   </dependencies>
                 </banDuplicateClasses>
               </rules>

--- a/hadoop-client-modules/hadoop-client-check-test-invariants/pom.xml
+++ b/hadoop-client-modules/hadoop-client-check-test-invariants/pom.xml
@@ -112,6 +112,26 @@
                         <ignoreClass>*</ignoreClass>
                       </ignoreClasses>
                     </dependency>
+                    <!--
+                      Both hadoop-client-runtime and hadoop-client-minicluster are multi-release jars and
+                      include a Java 9 module descriptor at META-INF/versions/9/module-info.class.
+                      This is not a real classpath conflict for our Java 8/11 builds, but it trips the
+                      BanDuplicateClasses rule when both artifacts are present.
+                    -->
+                    <dependency>
+                      <groupId>org.apache.hadoop</groupId>
+                      <artifactId>hadoop-client-runtime</artifactId>
+                      <ignoreClasses>
+                        <ignoreClass>META-INF/versions/9/module-info.class</ignoreClass>
+                      </ignoreClasses>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.hadoop</groupId>
+                      <artifactId>hadoop-client-minicluster</artifactId>
+                      <ignoreClasses>
+                        <ignoreClass>META-INF/versions/9/module-info.class</ignoreClass>
+                      </ignoreClasses>
+                    </dependency>
                   </dependencies>
                 </banDuplicateClasses>
               </rules>


### PR DESCRIPTION
Ignore `META-INF/versions/9/module-info.class` duplicates in Maven enforcer plugin to prevent build failures.

The `BanDuplicateClasses` rule was failing due to `META-INF/versions/9/module-info.class` being present in both `hadoop-client-runtime` and `hadoop-client-minicluster`. This is a legitimate occurrence for multi-release JARs and does not represent a real classpath conflict, so it is now explicitly ignored.

---
<a href="https://cursor.com/background-agent?bcId=bc-797667ce-d75c-4beb-b2a1-1652e52c6372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-797667ce-d75c-4beb-b2a1-1652e52c6372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

