### PR TITLE
OSV-22210 - CVE - Bumping aws-java-sdk version to 1.12.797 to fix CVE-2025-58057

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -191,7 +191,7 @@
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
-    <aws-java-sdk.version>1.12.782</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.797</aws-java-sdk.version>
     <hsqldb.version>2.7.1</hsqldb.version>
     <frontend-maven-plugin.version>1.11.2</frontend-maven-plugin.version>
     <jasmine-maven-plugin.version>2.1</jasmine-maven-plugin.version>


### PR DESCRIPTION
## Summary
- Bump  /  from **1.12.782 → 1.12.797** in .
- Addresses shaded Netty CVEs reported against  for ODP release **3.3.6.4**.

## Tickets closed
OSV-22210, OSV-22211, OSV-22215, OSV-22216, OSV-22217, OSV-22218, OSV-22219, OSV-22220, OSV-22221, OSV-22222, OSV-22223

## Test plan
- [ ] CI build on PR
- [ ] Confirm aws-java-sdk-bundle resolves to 1.12.797 in mapreduce deps