### PR TITLE
OSV-22186 - CVE - Bumping-up netty4 to 4.1.135.Final to fix CVE-2026-42579

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -149,7 +149,7 @@
     <jna.version>5.2.0</jna.version>
     <gson.version>2.9.0</gson.version>
     <metrics.version>3.2.4</metrics.version>
-    <netty4.version>4.1.132.Final</netty4.version>
+    <netty4.version>4.1.135.Final</netty4.version>
     <lz4-java.version>1.7.1</lz4-java.version>
 
     <!-- Maven protoc compiler -->


### PR DESCRIPTION
Bumps netty4.version 4.1.132.Final -> 4.1.135.Final in hadoop-project/pom.xml to fix the hadoop-owned netty CVEs (jars under hadoop-hdfs/lib). Covers: OSV-22186 (CVE-2026-42579), OSV-22189 (CVE-2026-42586), OSV-22206 (CVE-2026-42583), OSV-22224 (CVE-2026-44248), OSV-22229 (CVE-2026-41417), OSV-22230 (CVE-2026-42584), OSV-22231 (CVE-2026-42585), OSV-22232 (CVE-2026-42587), OSV-22233 (CVE-2026-42580), OSV-22234 (CVE-2026-42581), OSV-22240 (CVE-2026-42587). Built with JDK 11; all netty-consuming modules (Common, HDFS Client, HDFS, YARN API/Common/CSI) BUILD SUCCESS with netty 4.1.135.Final. NOTE: shaded fat-jar netty findings (hbase-shaded-netty, aws-java-sdk-bundle) are NOT addressed here - owned by their bundling components.