### PR TITLE
OSV-22228 - CVE - Bumping-up jackson-core to 2.18.6 to fix GHSA-72hv-8253-57qq

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -69,7 +69,7 @@
     <jersey.version>1.19.4</jersey.version>
 
     <!-- jackson versions -->
-    <jackson2.version>2.16.1</jackson2.version>
+    <jackson2.version>2.18.6</jackson2.version>
     <jackson2.databind.version>2.16.1</jackson2.databind.version>
 
     <!-- javax ws rs api version -->


### PR DESCRIPTION
Bumps jackson2.version (jackson-core) 2.16.1 -> 2.18.6 to fix GHSA-72hv-8253-57qq (jackson-core StackoverflowError on deeply nested input). 