### PR TITLE
OSV-22227 - CVE - Bumping-up okio-jvm to 3.4.0 to fix CVE-2023-3635

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -142,7 +142,7 @@
     <derby.version>10.17.1.0</derby.version>
     <mssql.version>6.2.1.jre7</mssql.version>
     <okhttp3.version>4.10.0</okhttp3.version>
-    <okio.version>3.2.0</okio.version>
+    <okio.version>3.4.0</okio.version>
     <kotlin-stdlib.verion>1.6.20</kotlin-stdlib.verion>
     <kotlin-stdlib-common.version>1.6.20</kotlin-stdlib-common.version>
     <jdom.version>1.1</jdom.version>


### PR DESCRIPTION
Bumps okio.version (okio-jvm) 3.2.0 -> 3.4.0 to fix CVE-2023-3635 (Okio GzipSource unhandled exception DoS). Built with JDK 11; hadoop-common and hadoop-hdfs-client (okio-jvm consumers) - BUILD SUCCESS.