### PR TITLE
ODP-7456 | OSV-22227: Bump Kotlin stdlib to 1.8.0 to align with okio-jvm:3.4.0

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -143,8 +143,8 @@
     <mssql.version>6.2.1.jre7</mssql.version>
     <okhttp3.version>4.10.0</okhttp3.version>
     <okio.version>3.4.0</okio.version>
-    <kotlin-stdlib.verion>1.6.20</kotlin-stdlib.verion>
-    <kotlin-stdlib-common.version>1.6.20</kotlin-stdlib-common.version>
+    <kotlin-stdlib.version>1.8.0</kotlin-stdlib.version>
+    <kotlin-stdlib-common.version>1.8.0</kotlin-stdlib-common.version>
     <jdom.version>1.1</jdom.version>
     <jna.version>5.2.0</jna.version>
     <gson.version>2.9.0</gson.version>
@@ -253,7 +253,7 @@
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib</artifactId>
-        <version>${kotlin-stdlib.verion}</version>
+        <version>${kotlin-stdlib.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.jetbrains</groupId>


### PR DESCRIPTION
okio-jvm:3.4.0 (bumped in OSV-22227 to fix CVE-2023-3635) depends on kotlin-stdlib-common:1.8.0 but the Kotlin version properties were not updated, leaving them at 1.6.20. This caused DependencyConvergence failures in downstream projects. Bump kotlin-stdlib and kotlin-stdlib-common to 1.8.0 to match.

Also fixes a pre-existing typo: kotlin-stdlib.verion → kotlin-stdlib.version.
