### PR TITLE
ODP-7266: Include jaxb-api in hadoop-client-runtime shade (#176)

### DIFF
--- a/hadoop-client-modules/hadoop-client-runtime/pom.xml
+++ b/hadoop-client-modules/hadoop-client-runtime/pom.xml
@@ -58,6 +58,15 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Ensure jaxb-api is shaded into this jar as org.apache.hadoop.shaded.javax.xml.bind.
+         Optional so it is not a transitive dependency of this artifact
+         (BanTransitiveDependencies in hadoop-client-check-invariants). -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
     <!-- At runtime anyone using us must have the api present -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
* ODP-7266: Include jaxb-api in hadoop-client-runtime shade

* ODP-7266: Include jaxb-api in hadoop-client-runtime shade

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
