### PR TITLE
OCR-2610: HDFS Namenode UI's Datanode tab doesn't work

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
@@ -393,6 +393,9 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
       </tr>
       {/DeadNodes}
     </table>


### PR DESCRIPTION
HDFS Namenode UI's Datanode tab doesn't work, add missing </td>

Test cluster: http://10.100.8.66:50070/dfshealth.html#tab-datanode