### PR TITLE
OCR-2610: HDFS Namenode UI's Datanode tab doesn't work (#185)

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/hdfs/dfshealth.html
@@ -381,6 +381,9 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
       </tr>
       {/DeadNodes}
     </table>


### PR DESCRIPTION
OCR-2610: HDFS Namenode UI's Datanode tab doesn't work, add missing </td> (#185)